### PR TITLE
Add FastAPI Excel upload service using DuckDB and Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+API_KEY=changeme
+UPLOAD_DIR=/data/uploads
+DB_PATH=/data/analytics.duckdb
+REDIS_URL=redis://redis:6379/0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+/data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install build deps for duckdb extension
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+COPY .env.example ./.env
+
+# Install & load duckdb excel extension at build time to cache
+RUN python - <<'PY'
+import duckdb
+con = duckdb.connect('dummy.db')
+con.execute('INSTALL excel;')
+PY
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,70 @@
 # crunchy
-Apply filters on massive excel files and view the desired data
+
+Backend service for uploading massive Excel files, tracking progress via Redis, and ingesting into DuckDB.
+
+## Features
+- **Streaming uploads** of arbitrarily large Excel files without exhausting memory.
+- **Background ingestion** into DuckDB using the Excel extension.
+- **Redis-backed progress tracking** with job polling endpoint.
+- **API key authentication** on protected endpoints.
+- **Health check** endpoint.
+- Packaged with **Docker** and orchestrated via **Docker Compose**.
+
+## Configuration
+Create a `.env` file (see `.env.example`):
+
+```env
+API_KEY=changeme
+UPLOAD_DIR=/data/uploads
+DB_PATH=/data/analytics.duckdb
+REDIS_URL=redis://redis:6379/0
+```
+
+## Running with Docker Compose
+```bash
+docker-compose up --build
+```
+The API will be available at `http://localhost:8000`.
+
+## API
+### Upload Excel file
+`POST /upload`
+
+Headers:
+- `X-API-Key`: API key from `.env`.
+
+Body: `multipart/form-data` with `file` field.
+
+Response:
+```json
+{"job_id": "<uuid>"}
+```
+
+### Check status
+`GET /status/{job_id}` with `X-API-Key` header.
+
+Response example:
+```json
+{
+  "status": "uploading",
+  "uploaded": 5242880,
+  "total": 10485760,
+  "table": null,
+  "error": null
+}
+```
+
+### Health
+`GET /health`
+
+Returns `{ "status": "ok" }`.
+
+## DuckDB Excel Extension
+The container installs and loads the DuckDB `excel` extension at startup, enabling `read_excel_auto` for ingestion.
+
+## Development
+Install dependencies and run tests:
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment."""
+
+    upload_dir: Path = Path("uploads")
+    db_path: Path = Path("analytics.duckdb")
+    redis_url: str = "redis://redis:6379/0"
+    api_key: str = "changeme"
+
+    class Config:
+        env_file = ".env"
+
+
+settings = Settings()
+UPLOAD_DIR = settings.upload_dir
+DB_PATH = settings.db_path
+REDIS_URL = settings.redis_url
+API_KEY = settings.api_key

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,116 @@
+import uuid
+from pathlib import Path
+
+import aiofiles
+import duckdb
+import redis
+from fastapi import BackgroundTasks, Depends, FastAPI, File, Header, HTTPException, Request, UploadFile
+from fastapi.responses import JSONResponse
+
+from .config import API_KEY, DB_PATH, REDIS_URL, UPLOAD_DIR
+
+app = FastAPI()
+redis_client = redis.Redis.from_url(REDIS_URL, decode_responses=True)
+
+
+# ---------------------------------------------------------------------------
+# Utility & startup
+# ---------------------------------------------------------------------------
+
+def verify_api_key(x_api_key: str = Header(None)):
+    if API_KEY and x_api_key != API_KEY:
+        raise HTTPException(status_code=401, detail="Invalid API Key")
+
+
+@app.on_event("startup")
+def startup_event():
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    conn = duckdb.connect(DB_PATH)
+    conn.execute("INSTALL excel;")
+    conn.execute("LOAD excel;")
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Background processing
+# ---------------------------------------------------------------------------
+
+def process_file(job_id: str, file_path: str):
+    job_key = f"job:{job_id}"
+    redis_client.hset(job_key, mapping={"status": "processing"})
+    try:
+        table = f"import_{job_id.replace('-', '_')}"
+        conn = duckdb.connect(DB_PATH)
+        conn.execute("LOAD excel;")
+        sql = f"""
+        CREATE OR REPLACE TABLE {table} AS
+        SELECT * FROM read_excel_auto('{file_path}');
+        """
+        conn.execute(sql)
+        conn.close()
+        redis_client.hset(job_key, mapping={"status": "completed", "table": table})
+    except Exception as e:  # pragma: no cover - error path
+        redis_client.hset(job_key, mapping={"status": "failed", "error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# API endpoints
+# ---------------------------------------------------------------------------
+
+@app.post("/upload")
+async def upload(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    file: UploadFile = File(...),
+    _: None = Depends(verify_api_key),
+):
+    job_id = str(uuid.uuid4())
+    filename = f"{job_id}_{file.filename}"
+    dest_path = UPLOAD_DIR / filename
+
+    total = request.headers.get("content-length")
+    total = int(total) if total and total.isdigit() else 0
+
+    job_key = f"job:{job_id}"
+    redis_client.hset(job_key, mapping={
+        "status": "uploading",
+        "uploaded": 0,
+        "total": total,
+        "table": "",
+        "error": "",
+    })
+
+    try:
+        async with aiofiles.open(dest_path, "wb") as out:
+            while chunk := await file.read(1024 * 1024):
+                await out.write(chunk)
+                redis_client.hincrby(job_key, "uploaded", len(chunk))
+    except Exception as e:  # pragma: no cover - error path
+        redis_client.hset(job_key, mapping={"status": "failed", "error": f"Upload error: {e}"})
+        raise HTTPException(500, "Failed to upload file.")
+
+    redis_client.hset(job_key, mapping={"status": "queued"})
+    background_tasks.add_task(process_file, job_id, str(dest_path))
+    return {"job_id": job_id}
+
+
+@app.get("/status/{job_id}")
+def status(job_id: str, _: None = Depends(verify_api_key)):
+    job_key = f"job:{job_id}"
+    data = redis_client.hgetall(job_key)
+    if not data:
+        raise HTTPException(404, "Unknown job_id")
+    # Convert numeric fields
+    response = {
+        "status": data.get("status"),
+        "uploaded": int(data.get("uploaded", 0)),
+        "total": int(data.get("total", 0)) or None,
+        "table": data.get("table") or None,
+        "error": data.get("error") or None,
+    }
+    return JSONResponse(response)
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+services:
+  api:
+    build: .
+    env_file: .env
+    volumes:
+      - ./data:/data
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redis
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+volumes:
+  redis-data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+fastapi
+uvicorn[standard]
+aiofiles
+duckdb
+redis
+python-dotenv
+pydantic
+pytest
+httpx
+pydantic-settings
+python-multipart
+fakeredis

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+import fakeredis
+
+import app.main as main
+
+# Replace redis client with fakeredis
+main.redis_client = fakeredis.FakeRedis(decode_responses=True)
+app = main.app
+
+client = TestClient(app)
+
+
+def test_health():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_status_unknown_job():
+    response = client.get("/status/unknown", headers={"X-API-Key": "changeme"})
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- implement FastAPI backend with streaming Excel upload and background ingestion into DuckDB
- track job progress via Redis and expose status & health endpoints
- add Docker/Docker Compose setup with DuckDB Excel extension and configuration via .env

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894f5b1d7d0832d8dd3d51a0d4c8cbd