### PR TITLE
Add websocket status updates and granular job progress

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ httpx
 pydantic-settings
 python-multipart
 fakeredis
+pyarrow

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,9 @@
 from fastapi.testclient import TestClient
 import fakeredis
+import sys
+from pathlib import Path
 
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 import app.main as main
 
 # Replace redis client with fakeredis
@@ -19,3 +22,9 @@ def test_health():
 def test_status_unknown_job():
     response = client.get("/status/unknown", headers={"X-API-Key": "changeme"})
     assert response.status_code == 404
+
+
+def test_ws_status_unknown_job():
+    with client.websocket_connect("/ws/status/unknown") as websocket:
+        data = websocket.receive_json()
+        assert data == {"error": "unknown job"}


### PR DESCRIPTION
## Summary
- stream job progress with a new `/ws/status/{job_id}` WebSocket endpoint
- chunk-read CSV and Parquet uploads, updating row counts in Redis
- include row counts in status API and add pyarrow dependency

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894f8432cd8832d8b25b7391b2697ac