### PR TITLE
Enable CORS for upload endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -19,10 +19,18 @@ from fastapi import (
     WebSocket,
 )
 from fastapi.responses import JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
 
 from .config import API_KEY, DB_PATH, REDIS_URL, UPLOAD_DIR
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 redis_client = redis.Redis.from_url(REDIS_URL, decode_responses=True)
 
 


### PR DESCRIPTION
## Summary
- add FastAPI CORS middleware to allow frontend uploads

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895831130dc832db9807e0e5b278cac