### PR TITLE
Add NDJSON streaming endpoint for large result sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,24 @@ Response:
 
 Repeated queries are cached in-memory for speed, and specifying `fields` trims unused columns to reduce I/O.
 
+### Stream query results
+`POST /tables/{table}/stream` with `X-API-Key` header.
+
+This returns an `application/x-ndjson` stream where each line is a JSON object representing a row. Example:
+
+```
+curl -N -H "X-API-Key: changeme" -X POST \
+  http://localhost:8000/tables/mytable/stream \
+  -d '{"limit":1000,"offset":0}'
+```
+
+```
+{"id":1,"name":"Alice"}
+{"id":2,"name":"Bob"}
+```
+
+Use this for exporting large result sets without loading them all into memory.
+
 ### Health
 `GET /health`
 


### PR DESCRIPTION
## Summary
- add `/tables/{table_name}/stream` endpoint that streams NDJSON rows
- document NDJSON streaming API usage
- cover streaming with tests, including empty and unknown-table cases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895fb333ff8832dafd19ab6845e16f5