### PR TITLE
Add case-insensitive filter operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,33 @@ Response:
 {"rows": [{"id": 1, "age": 42, "country": "UAE"}], "total": 1}
 ```
 
+Supported filter operators include:
+
+- `eq`, `neq`, `lt`, `lte`, `gt`, `gte`
+- `like` (case-sensitive contains)
+- `ilike` (case-insensitive contains)
+- `ieq` (case-insensitive equals)
+- `in`, `between`, `in_range`
+- `is_null`, `is_not_null`
+
+Examples:
+
+- Case-insensitive contains:
+
+  ```json
+  { "column": "name", "op": "ilike", "value": "smith" }
+  ```
+
+  generates `WHERE "name" ILIKE '%smith%'`
+
+- Case-insensitive equals:
+
+  ```json
+  { "column": "status", "op": "ieq", "value": "ACTIVE" }
+  ```
+
+  generates `WHERE LOWER("status") = LOWER('ACTIVE')`
+
 Repeated queries are cached in Redis for speed, and specifying `fields` trims unused columns to reduce I/O.
 
 ### Stream query results

--- a/app/main.py
+++ b/app/main.py
@@ -128,6 +128,8 @@ class Filter(BaseModel):
         "gt",
         "gte",
         "like",
+        "ilike",
+        "ieq",
         "in",
         "between",
         "in_range",
@@ -240,6 +242,12 @@ def _prepare_query(table_name: str, req: QueryRequest):
             return f"{col} IS NULL", []
         elif flt.op == "is_not_null":
             return f"{col} IS NOT NULL", []
+        elif flt.op == "ilike":
+            v = flt.value if isinstance(flt.value, str) else str(flt.value)
+            return f"{col} ILIKE ?", [f"%{v}%"]
+        elif flt.op == "ieq":
+            v = flt.value if isinstance(flt.value, str) else str(flt.value)
+            return f"LOWER({col}) = LOWER(?)", [v]
         else:
             op_sql = {
                 "eq": "=",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -141,6 +141,8 @@ function App() {
                 <option value="gt">&gt;</option>
                 <option value="gte">&ge;</option>
                 <option value="like">like</option>
+                <option value="ilike">ilike</option>
+                <option value="ieq">ieq</option>
               </select>
               <input
                 data-testid={`value-${idx}`}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -287,6 +287,8 @@ def test_filter_operations():
     assert q({"filters": [{"column": "age", "op": "gt", "value": 30}], "fields": ["id"]})["rows"] == [{"id": 4}]
     assert q({"filters": [{"column": "age", "op": "gte", "value": 30}], "fields": ["id"]})["rows"] == [{"id": 1}, {"id": 4}]
     assert q({"filters": [{"column": "name", "op": "like", "value": "li"}], "fields": ["id"]})["rows"] == [{"id": 1}]
+    assert q({"filters": [{"column": "name", "op": "ilike", "value": "ALI"}], "fields": ["id"]})["rows"] == [{"id": 1}]
+    assert q({"filters": [{"column": "name", "op": "ieq", "value": "ALICE"}], "fields": ["id"]})["rows"] == [{"id": 1}]
     assert q({"filters": [{"column": "id", "op": "in", "value": [1, 3]}], "fields": ["id"]})["rows"] == [{"id": 1}, {"id": 3}]
     assert q({"filters": [{"column": "age", "op": "between", "value": [20, 35]}], "fields": ["id"]})["rows"] == [{"id": 1}, {"id": 3}]
     assert q({"filters": [{"column": "age", "op": "in_range", "value": [40, 25, 30]}], "fields": ["id"]})["rows"] == [{"id": 1}, {"id": 3}, {"id": 4}]


### PR DESCRIPTION
## Summary
- support `ilike` and `ieq` filter operations for case-insensitive contains and equals
- document new operators and expose them in the frontend
- test `ilike` and `ieq` query behavior

## Testing
- `pytest`
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689622ec884c832dac3ebd8149be5ec6