### PR TITLE
Add Caddy reverse proxy service

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,3 @@
+:80 {
+    reverse_proxy api:8000
+}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ docker-compose up --build
 ```
 The API will be available at `http://localhost:8000` and the frontend at `http://localhost:5173`.
 
+To serve the API (and optionally the frontend) over HTTP/HTTPS on standard ports, a Caddy reverse proxy container is included. A sample `Caddyfile` is provided that proxies incoming requests on port 80 to the `api` service.
+
 Open the frontend in your browser, supply the API key, select a file, and click **Upload**. When the upload finishes the first few rows are displayed and you can add filters to refine the results via the new query endpoints. Upload progress and row ingestion counts update live using the WebSocket status API.
 
 ## API

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,5 +52,19 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  caddy:
+    image: caddy:2-alpine
+    container_name: crunchy_caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - /data/caddy:/data
+      - /data/caddy-config:/config
+    depends_on:
+      - api
+
 volumes:
   redis-data:


### PR DESCRIPTION
## Summary
- add a Caddy container to `docker-compose.yml` for HTTP/HTTPS reverse proxying
- document the proxy setup and provide a sample `Caddyfile`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d9cd8438c832db7aa2ebad5cff8e3